### PR TITLE
Fix "... docker-compose.yaml is invalid" error

### DIFF
--- a/deployments/docker_compose/docker-compose.yaml
+++ b/deployments/docker_compose/docker-compose.yaml
@@ -46,8 +46,7 @@ services:
     ports:
       - "${APP_DOCKER_PORT-8000}:8000"
     depends_on:
-      postgres:
-        condition: service_healthy
+      - postgres
     healthcheck:
       test: curl --fail -s $$HEALTH_CHECK_GOVREADY_Q || exit 1
       interval: 10s
@@ -67,8 +66,7 @@ services:
     ports:
       - "${HOST_PORT_HTTPS-443}:443"
     depends_on:
-      app:
-        condition: service_healthy
+      - app
     networks:
       - q_network
 
@@ -77,11 +75,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - type: volume
-        source: postgres-data
-        target: /postgres-data
-        volume:
-          nocopy: false
+      - postgres-data:/postgres-data
     environment:
       POSTGRES_DB: govready_q
       POSTGRES_PASSWORD: PASSWORD


### PR DESCRIPTION
Fixes the following error:
```bash
ERROR: The Compose file './docker-compose.yaml' is invalid because:
services.app.depends_on contains an invalid type, it should be an array
services.nginx.depends_on contains an invalid type, it should be an array
services.postgres.volumes contains an invalid type, it should be a string
```