### PR TITLE
Add HOST_PORT_HTTP to support certbot SSL creation

### DIFF
--- a/deployments/docker_compose/README.md
+++ b/deployments/docker_compose/README.md
@@ -14,7 +14,7 @@ Make sure you have the following installed:
 | HOST_ADDRESS                      | ✔     | GovReady-Q's public address as would be entered in a web browser. |
 | ALLOWED_HOSTS                     | ❌    | GovReady-Q's approved list of host names provided as an array. If not provided, will default to HOST_ADDRESS. |
 | HOST_PORT_HTTPS                   | ✔     | GovReady-Q's public address HTTPS port; defaults to 443 |
-| HOST_PORT_HTTP                    | ❌    | GovReady-Q's public address HTTP port; defaults to 80 |
+| HOST_PORT_HTTP                    | ❌    | GovReady-Q's public address HTTP port; defaults to 80   |
 | ADMINS                            | ✔    | Administrator accounts. Ex: `[{"username": "username", "email":"first.last@example.com", "password": "REPLACEME"}]`     | Will auto-create an admin, you need to find it in the logs docker-compose logs                       |
 | BRANDING                          | ❌    | Full file path to GovReady-Q branding directory                                                                       | GovReady default branding will be used.                                                              |
 | DATABASE_CONNECTION_STRING        | ❌    | Database connection string: `<db_connector>://<name>:<password>@<host>:<port>/<db_name>`                                | Will create a Postgres server in the docker-compose deployment for you.  It will not have snapshots. |
@@ -50,13 +50,15 @@ The Docker container running the default PostgreSQL is Alpine Linux. The Postgre
 - Remove existing docker build - then:
 - `docker volume rm govready-q_postgres-data`
 
-## Local Host Database
+## Running Database on Host or Seperate Server
 
-It is also possible to connect Docker-ized GovReady-Q instance to a PostgreSQL database instance running on HOST machine (i.e., not in Docker) following the below instructions.
+You can also connect a Docker-ized GovReady-Q instance to a persistent Postgres database running on:
 
-This configuration provides a persistent Postgres database on the Host machine that is used by a GovReady deployment running withing docker containers on the host machine.
+1. the Host machine that is used by a GovReady deployment running the docker containers (e.g., Postgres not in a container)
+2. a second server
+3. a managed Postgres service run by you Cloud Service Provider
 
-(Instructions for Ubuntu 18.04. Adjust appropriately for your OS.)
+The following instructions are for option #1 on Ubuntu 18.04, which keeps everything on one server while reducing the chance of accidentally wiping a containerized Postgres database. (Adjust appropriately for your OS.)
 
 For additional information see https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html.
 
@@ -64,13 +66,13 @@ For additional information see https://www.postgresql.org/docs/current/static/au
 
 Modify the Host's Postgres configuration file `/etc/postgresql/10/main/postgresql.conf` to instruct Postgres to listen on the Host machine's IP address, Host name, etc.:
 
-```
+```bash
 listen_addresses = 'localhost, ip_address, domain_name'
 ```
 
 Example:
 
-```
+```bash
 listen_addresses = 'localhost, 10.1.0.10'
 ```
 
@@ -78,11 +80,13 @@ listen_addresses = 'localhost, 10.1.0.10'
 
 Modify Host's Postgres configuration file `/etc/postgres/10/main/pg_hba.conf` to permit connection from the GovReady-Q instance running in the docker container by allowing a connection from the IP address the Host perceives for the docker container.
 
-GovReady-Q's docker compose network is configured with the IP address `172.32.0.0/24`. (If you deployed GovReady using Docker-Compose, the IP address will be that of the Docker-Compose network bridge. If you deployed GovReady using a single container, the IP address will be that of the container's IP address.)
+GovReady-Q's docker compose network is configured with the IP address `172.32.0.0/24`.
+
+NOTES: If you deployed GovReady using Docker-Compose, the IP address will be that of the Docker-Compose network bridge. If you deployed GovReady using a single container, the IP address will be that of the container's IP address. If you are connecting to a database on a remote server, the IP address of the GovReady-Q instance is the Host machine's IP address.
 
 Configure `pg_hba.conf` to permit connections from the perceived IP address of docker network (or container):
 
-```
+```bash
 host all all 172.32.0.0/24 password
 local all postgres peer
 ...
@@ -127,18 +131,94 @@ This configuration provides a persistent Postgres database on the Host machine t
 
 When a `Server Error (500)` appears the will almost always be written to the log file in the `govready-q_app_1` container and can be accessed from the following `tail` command on the HOST machine:
 
-```
+```bash
 tail <path_to>/govready-deployments/volumes/govready-q/logs/gunicorn.error.log
 ```
 
 This file can also be reached from the GovReady-Q container (govready-q_app_1):
 
+```bash
+docker exec -it govready-q_app_1 tail /var/log/gunicorn.error.log
 ```
-sudo docker exec -it govready-q_app_1 tail /var/log/gunicorn.error.log
-```
+
+NOTE: You may need to prefix your docker commands with `sudo` depending on the relative ownership of Docker and ownership and install directory of `govready-deployments` on your Host.
 
 The STDOUT of the GovReady-Q as it runs can be viewed by attaching in a terminal to the GovReady-Q container via the command (for example):
 
+```bash
+docker attach govready-q_app_1
 ```
-sudo docker attach govready-q_app_1
+
+## Setting up SSL via Let's Encrypt certbot
+
+The following instructions describe the general process of using Let's Encrypt certbot to configure an SSL certificate for your instance on Ubuntu 18.04. (Adjust appropriately for your OS.)
+
+GovReady-Q's NGINX is preconfigred to allow port 80 access to the path where certbot adds a file for validating the domain.
+
+You may find it useful to read one of the many posts online regarding certbot for additional hints.
+
+### Step 1 - Connect to NGINX instance.
+
+First, connect to NINGX running in the Docker container.
+
+```bash
+docker exec -it govready-q_nginx_1 /bin/sh
 ```
+
+NOTE: The NGINX container uses the Alpine OS.
+
+### Step 2 - Install certbot
+
+Install certbot and it’s NINGX plugin with apt:
+
+```bash
+apk add certbot certbot-nginx
+```
+
+NOTE: The NINGX configure file is `/etc/nginx/nginx.conf `. Also, `sudo` is not installed in the Alpine NGINX container. You are root when you exec'ed into the container.
+
+### Step 3 - Run certbot to Obtain an SSL Certificate
+
+Now run certbot by typing the following:
+
+```bash
+certbot --nginx -d example.com
+```
+
+This runs certbot with the --nginx plugin, using -d to specify the domain names for the certificate. Be sure to use the same domain as specified GovReady's configuration file (e.g., "HOST_ADDRESS": "example.com").
+
+You will be prompted to enter an email address, agree to the terms of service and other information. certbot will communicate with the Let’s Encrypt server, then run a challenge to verify that you control the domain. GovReady-Q's NGINX is preconfigred to allow port 80 access to the path where certbot adds a file for validating the domain. certbot's NGINX plugin will reconfiguring NGINX and reload the config whenever necessary. 
+
+Complete any additional certbot prompts to configure your HTTPS settings.
+
+NOTE: Firewall configurations that block access over port 80 and 443 are a common source of certbot failures. Make sure your Host firewall (and any other firewalls) are properly configured to allow port 80 and port 443 access for inbound remote requests.
+
+### Step 4 - Access your Server
+
+You should now be able to access your server via HTTPS and see a valid certificate.
+
+### Step 5 - Exit the Container
+
+You're done. Type the following to exit the NGINX container:
+
+```bash
+exit
+```
+
+### Step 6 - Routinely Renew the Certificate
+
+Re-run certbot every ninety days to renew the certificate by typing the following:
+
+```bash
+docker exec -it govready-q_nginx_1 /bin/sh
+certbot --nginx -d example.com
+```
+
+Alternatively, allow certbot to automatically renew by typing the following:
+
+```bash
+systemctl status certbot.timer
+```
+
+
+

--- a/deployments/docker_compose/README.md
+++ b/deployments/docker_compose/README.md
@@ -47,8 +47,12 @@ The local database running in Docker container is persisted between deploys in a
 The Docker container running the default PostgreSQL is Alpine Linux. The PostgreSQL configuration files located in the `/postgres-data` directory (e.g., `/postgres-data/postgresql.conf`).
 
 #### Wipe Local Docker Database Volume
-- Remove existing docker build - then:
-- `docker volume rm govready-q_postgres-data`
+
+Remove existing docker build - then:
+
+```bash
+docker volume rm govready-q_postgres-data`
+```
 
 ## Running Database on Host or Seperate Server
 

--- a/deployments/docker_compose/README.md
+++ b/deployments/docker_compose/README.md
@@ -14,7 +14,8 @@ Make sure you have the following installed:
 | HOST_ADDRESS                      | ✔     | GovReady-Q's public address as would be entered in a web browser. |
 | ALLOWED_HOSTS                     | ❌    | GovReady-Q's approved list of host names provided as an array. If not provided, will default to HOST_ADDRESS. |
 | HOST_PORT_HTTPS                   | ✔     | GovReady-Q's public address HTTPS port; defaults to 443 |
-| ADMINS                            | ❌    | Administrator accounts. Ex: `[{"username": "username", "email":"first.last@example.com", "password": "REPLACEME"}]`     | Will auto-create an admin, you need to find it in the logs docker-compose logs                       |
+| HOST_PORT_HTTP                    | ❌    | GovReady-Q's public address HTTP port; defaults to 80 |
+| ADMINS                            | ✔    | Administrator accounts. Ex: `[{"username": "username", "email":"first.last@example.com", "password": "REPLACEME"}]`     | Will auto-create an admin, you need to find it in the logs docker-compose logs                       |
 | BRANDING                          | ❌    | Full file path to GovReady-Q branding directory                                                                       | GovReady default branding will be used.                                                              |
 | DATABASE_CONNECTION_STRING        | ❌    | Database connection string: `<db_connector>://<name>:<password>@<host>:<port>/<db_name>`                                | Will create a Postgres server in the docker-compose deployment for you.  It will not have snapshots. |
 | MOUNT_FOLDER                      | ❌    | Mount folder to put artifacts, logs, etc.                                                                             | Current directory                                                                                    |
@@ -37,9 +38,107 @@ Make sure you have the following installed:
 
 To build an empty configuration file use `python run.py init` at the root of the project.
 
-## Local Database
-The local database is persisted in a Docker Volume called `govready-q_postgres-data`
+## Local Docker Database
 
-#### Wipe
+A local Docker container running PostgreSQL will automatically be added when the `configuration.json` file's `DATABASE_CONNECTION_STRING` is set to `""`.
+
+The local database running in Docker container is persisted between deploys in a Docker Volume called `govready-q_postgres-data` to preserve data.
+
+The Docker container running the default PostgreSQL is Alpine Linux. The PostgreSQL configuration files located in the `/postgres-data` directory (e.g., `/postgres-data/postgresql.conf`).
+
+#### Wipe Local Docker Database Volume
 - Remove existing docker build - then:
 - `docker volume rm govready-q_postgres-data`
+
+## Local Host Database
+
+It is also possible to connect Docker-ized GovReady-Q instance to a PostgreSQL database instance running on HOST machine (i.e., not in Docker) following the below instructions.
+
+This configuration provides a persistent Postgres database on the Host machine that is used by a GovReady deployment running withing docker containers on the host machine.
+
+(Instructions for Ubuntu 18.04. Adjust appropriately for your OS.)
+
+For additional information see https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html.
+
+### Step 1 - Configure postgresql.conf
+
+Modify the Host's Postgres configuration file `/etc/postgresql/10/main/postgresql.conf` to instruct Postgres to listen on the Host machine's IP address, Host name, etc.:
+
+```
+listen_addresses = 'localhost, ip_address, domain_name'
+```
+
+Example:
+
+```
+listen_addresses = 'localhost, 10.1.0.10'
+```
+
+### Step 2 - Configure pg_hba.conf
+
+Modify Host's Postgres configuration file `/etc/postgres/10/main/pg_hba.conf` to permit connection from the GovReady-Q instance running in the docker container by allowing a connection from the IP address the Host perceives for the docker container.
+
+GovReady-Q's docker compose network is configured with the IP address `172.32.0.0/24`. (If you deployed GovReady using Docker-Compose, the IP address will be that of the Docker-Compose network bridge. If you deployed GovReady using a single container, the IP address will be that of the container's IP address.)
+
+Configure `pg_hba.conf` to permit connections from the perceived IP address of docker network (or container):
+
+```
+host all all 172.32.0.0/24 password
+local all postgres peer
+...
+```
+
+### Step 3 - Restart Postgres
+
+Restart Postgres:
+
+```
+sudo service postgresql stop
+sudo service postgresql start
+```
+
+### Step 4 - Configure GovReady Deployment configuration.json
+
+Modify GovReady's docker deployment configuration file `configuration_mantech.json` to have Postgres database connection string that includes the Host IP address running the Postgres instance.
+
+`"DATABASE_CONNECTION_STRING": "postgres://username:password@host/dbname",`
+
+Example:
+
+`"DATABASE_CONNECTION_STRING": "postgres://govready-q:s&kerjkDKW231@10.1.0.10/govreadydb",`
+
+### Step 5 - Restart GovReady container stack
+
+Restart GovReady stack appropriately.
+
+
+# BACKUP POSTGRES DATABASE
+
+1. Look up password in file `/home/govready-q/local/environment.json`.
+1. Run: `pg_dump postres -U example_user -h localhost > <file_path>/pg_dump_<date>.sql`
+
+## Remote Database
+
+It is also possible to connect Docker-ized GovReady-Q instance to a PostgreSQL database instance running on a different machine (i.e., remote database) following the below instructions.
+
+This configuration provides a persistent Postgres database on the Host machine that is used by a GovReady deployment running withing docker containers on the host machine.
+
+## Viewing Logs
+
+When a `Server Error (500)` appears the will almost always be written to the log file in the `govready-q_app_1` container and can be accessed from the following `tail` command on the HOST machine:
+
+```
+tail <path_to>/govready-deployments/volumes/govready-q/logs/gunicorn.error.log
+```
+
+This file can also be reached from the GovReady-Q container (govready-q_app_1):
+
+```
+sudo docker exec -it govready-q_app_1 tail /var/log/gunicorn.error.log
+```
+
+The STDOUT of the GovReady-Q as it runs can be viewed by attaching in a terminal to the GovReady-Q container via the command (for example):
+
+```
+sudo docker attach govready-q_app_1
+```

--- a/deployments/docker_compose/config-validator.json
+++ b/deployments/docker_compose/config-validator.json
@@ -3,6 +3,7 @@
   {"key": "ALLOWED_HOSTS", "required": false, "description":  "GovReady-Q's approved list of host names.  If not provided, will default to HOST_ADDRESS."},
   {"key": "HOST_ADDRESS", "required": true, "description":  "GovReady-Q's public address as would be entered in a web browser."},
   {"key": "HOST_PORT_HTTPS", "required": true, "description":  "GovReady-Q's public address HTTPS port; defaults to 443"},
+  {"key": "HOST_PORT_HTTP", "required": false, "description":  "GovReady-Q's public address HTTP port; defaults to 80"},
 
   {"key": "ADMINS", "required": false, "description":  "Administrator accounts. Ex: [{\"username\": \"username\", \"email\":\"first.last@example.com\", \"password\": \"REPLACEME\"}]", "default-message":  "Will auto-create an admin, you need to find it in the logs docker-compose logs"},
   {"key": "MOUNT_FOLDER", "required": false, "description":  "Mount folder to put artifacts, logs, etc.", "default-message":  "Current directory."},

--- a/deployments/docker_compose/deploy.py
+++ b/deployments/docker_compose/deploy.py
@@ -74,8 +74,8 @@ class DockerComposeDeployment(Deployment):
         self.execute(cmd=f"docker-compose -f {docker_compose_file} down {self.FAIL_SUFFIX}")
 
         self.REQUIRED_PORTS += [int(self.config['HOST_PORT_HTTPS']),
-                                int(self.config['APP_DOCKER_PORT']),
-                                int(self.config['CERTBOT_PORT'])
+                                int(self.config['HOST_PORT_HTTP']),
+                                int(self.config['APP_DOCKER_PORT'])
                                 ]
         self.check_ports()
         self.execute(cmd=f"docker-compose -f {docker_compose_file} up -d", show_env=True)

--- a/deployments/docker_compose/deploy.py
+++ b/deployments/docker_compose/deploy.py
@@ -55,6 +55,7 @@ class DockerComposeDeployment(Deployment):
         self.config['ALLOWED_HOSTS'] = ['app', self.config['HOST_ADDRESS']] + getattr(self.config, 'ALLOWED_HOSTS', [])
         self.set_default('DEBUG', "false")
         self.set_default('APP_DOCKER_PORT', "18000")
+        self.set_default('CERTBOT_PORT', "80")
 
         if self.check_if_valid_uri(self.config['HOST_ADDRESS']):
             Prompt.error(f"HOST_ADDRESS cannot be a valid URI.  It must be the domain only.  "
@@ -73,7 +74,8 @@ class DockerComposeDeployment(Deployment):
         self.execute(cmd=f"docker-compose -f {docker_compose_file} down {self.FAIL_SUFFIX}")
 
         self.REQUIRED_PORTS += [int(self.config['HOST_PORT_HTTPS']),
-                                int(self.config['APP_DOCKER_PORT'])
+                                int(self.config['APP_DOCKER_PORT']),
+                                int(self.config['CERTBOT_PORT'])
                                 ]
         self.check_ports()
         self.execute(cmd=f"docker-compose -f {docker_compose_file} up -d", show_env=True)

--- a/deployments/docker_compose/docker-compose.external-db.yaml
+++ b/deployments/docker_compose/docker-compose.external-db.yaml
@@ -24,6 +24,7 @@ services:
       - ALLOWED_HOSTS=${ALLOWED_HOSTS-}
       - HOST_ADDRESS=${HOST_ADDRESS-}
       - HOST_PORT_HTTPS=${HOST_PORT_HTTPS-}
+      - HOST_PORT_HTTP=${HOST_PORT_HTTP-}
       - APP_DOCKER_PORT=${APP_DOCKER_PORT-}
       - SECRET_KEY=${SECRET_KEY-}
       - DEBUG=${DEBUG-}
@@ -67,6 +68,7 @@ services:
       - APP_DOCKER_PORT=${APP_DOCKER_PORT-}
     ports:
       - "${HOST_PORT_HTTPS-443}:443"
+      - "${HOST_PORT_HTTP-80}:80"
     depends_on:
       - app
     networks:

--- a/deployments/docker_compose/docker-compose.yaml
+++ b/deployments/docker_compose/docker-compose.yaml
@@ -69,6 +69,7 @@ services:
       - APP_DOCKER_PORT=${APP_DOCKER_PORT-}
     ports:
       - "${HOST_PORT_HTTPS-443}:443"
+      - "${HOST_PORT_HTTPS-80}:80"
     depends_on:
       - app
     networks:

--- a/deployments/docker_compose/docker-compose.yaml
+++ b/deployments/docker_compose/docker-compose.yaml
@@ -24,8 +24,8 @@ services:
       - ALLOWED_HOSTS=${ALLOWED_HOSTS-}
       - HOST_ADDRESS=${HOST_ADDRESS-}
       - HOST_PORT_HTTPS=${HOST_PORT_HTTPS-}
+      - HOST_PORT_HTTP=${HOST_PORT_HTTP-}
       - APP_DOCKER_PORT=${APP_DOCKER_PORT-}
-      - CERTBOT_PORT=80
       - SECRET_KEY=${SECRET_KEY-}
       - DEBUG=${DEBUG-}
       - ADMINS=${ADMINS-[]}
@@ -70,7 +70,7 @@ services:
       - APP_DOCKER_PORT=${APP_DOCKER_PORT-}
     ports:
       - "${HOST_PORT_HTTPS-443}:443"
-      - "${CERTBOT_PORT-80}:80"
+      - "${HOST_PORT_HTTP-80}:80"
     depends_on:
       - app
     networks:

--- a/deployments/docker_compose/docker-compose.yaml
+++ b/deployments/docker_compose/docker-compose.yaml
@@ -69,7 +69,7 @@ services:
       - APP_DOCKER_PORT=${APP_DOCKER_PORT-}
     ports:
       - "${HOST_PORT_HTTPS-443}:443"
-      - "${HOST_PORT_HTTPS-80}:80"
+      - "80:80"
     depends_on:
       - app
     networks:

--- a/deployments/docker_compose/docker-compose.yaml
+++ b/deployments/docker_compose/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
       - HOST_ADDRESS=${HOST_ADDRESS-}
       - HOST_PORT_HTTPS=${HOST_PORT_HTTPS-}
       - APP_DOCKER_PORT=${APP_DOCKER_PORT-}
+      - CERTBOT_PORT=80
       - SECRET_KEY=${SECRET_KEY-}
       - DEBUG=${DEBUG-}
       - ADMINS=${ADMINS-[]}
@@ -69,7 +70,7 @@ services:
       - APP_DOCKER_PORT=${APP_DOCKER_PORT-}
     ports:
       - "${HOST_PORT_HTTPS-443}:443"
-      - "80:80"
+      - "${CERTBOT_PORT-80}:80"
     depends_on:
       - app
     networks:

--- a/images/govready-q/docker_exec_write_environment.sh
+++ b/images/govready-q/docker_exec_write_environment.sh
@@ -6,6 +6,7 @@ cat << EOF > local/environment.json
 {
 	"debug": ${DEBUG-false},
 	"host": "$(echo "${HOST_ADDRESS}:${HOST_PORT_HTTPS}" )",
+	"host_http": "$(echo "${HOST_ADDRESS}:${HOST_PORT_HTTP}" )",
 	"secret-key": $(echo ${SECRET_KEY-} | jq -R .),
 	"syslog": $(echo ${SYSLOG-} | jq -R .),
 	"govready_admins": ${ADMINS-[]},

--- a/images/nginx/nginx.conf
+++ b/images/nginx/nginx.conf
@@ -33,6 +33,11 @@ http {
     server {
         listen       80 default_server;
         listen       [::]:80 default_server;
+        # Permit letsencrypt certbot challenge to easily add SSL certificate 
+        location ~ ^/.well-known/acme-challenge {
+             allow all;
+             root /data/letsencrypt;
+        }
         server_name  _;
         return       301 https://$host$request_uri;
     }


### PR DESCRIPTION
Changes to make installing letsencrypt SSL.


Terminal commands for viewing nginx configuration file from using govready-deployments.

1. Start in terminal within govready-deployments directory.
2. Connect to Docker container for NGINX.
3. Look at `/etc/nginx/nginx_conf` file


```text
# exec into docker nginx container
docker exec -it govready-q_nginx_1 /bin/sh

# look at nginx.conf file
cat /etc/nginx/nginx.conf 

# output
worker_processes 1;

events { worker_connections 1024; }

http {
    client_max_body_size 20M;
    sendfile on;

    upstream govready-q-upstream {
        server app:18000;
    }

    server {
        listen              443 ssl;
        server_name         loginsoft.govready.com;
        ssl_certificate     /etc/pki/tls/certs/cert.pem;
        ssl_certificate_key /etc/pki/tls/private/key.pem;
        ssl_protocols       TLSv1.3 TLSv1.2;
        ssl_ciphers         HIGH:!aNULL:!MD5;
        add_header Strict-Transport-Security "max-age=31536000;" always;

        location / {
            proxy_pass         http://govready-q-upstream;
            proxy_redirect     off;
            proxy_set_header   Host $http_host;
            proxy_set_header   X-Forwarded-Proto $scheme;
            proxy_set_header   X-Real-IP $remote_addr;
            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header   X-Forwarded-Host $server_name;
        }
    }

    server {
        listen       80 default_server;
        listen       [::]:80 default_server;

        #for certbot challenges
        location ~ ^/.well-known/acme-challenge {
             allow all;
             root /data/letsencrypt;
        }

        server_name  _;
        return       301 https://$host$request_uri;
    }
```